### PR TITLE
Update mavesp8266_httpd.cpp

### DIFF
--- a/src/mavesp8266_httpd.cpp
+++ b/src/mavesp8266_httpd.cpp
@@ -271,7 +271,7 @@ static void handle_setup()
     message += "<form action='/setparameters' method='post'>\n";
 
     message += "WiFi Mode:&nbsp;";
-    message += "<input type='radio' name='mode' value='0'";
+    message += "<input type='radio' name='mode' value='2'"; //Changed to 2 instead of 0 
     if (getWorld()->getParameters()->getWifiMode() == WIFI_MODE_AP) {
         message += " checked";
     }


### PR DESCRIPTION
Hello ! After several tests , I discovered a small bug in the selection of AP or STA mode in the WEB page . 
Proabibly by adding this file :`#include <esp_wifi_types.h>`

The modes have changed number , in fact before they were :
AP =0 
STA =1
Now they seem to be :
AP=2
STA =1 
This change was not shown on the Web page and so once I had entered the STA mode I was not able to go back to the AP mode because the radio button changed the AP mode to 0 and not 2 and since 0 was not recognized the system would freeze . Saying that the AP radio button should set 2 instead of 0 , seems to solve the problem , now I can change modes perfectly .
The other parameters seem to be working